### PR TITLE
Check module availability for each cType

### DIFF
--- a/lib/module_preview.php
+++ b/lib/module_preview.php
@@ -69,58 +69,19 @@ class module_preview extends rex_article_content_editor
         $context->setParam('source_slice_id', '');
         $this->modules = [];
 
+        // Build cards for all modules available to the user and the current template.
         foreach ($modules as $m) {
             // Check if the user has permission to use the module
             if (true !== (rex::getUser()->getComplexPerm('modules')->hasPerm($m['id']) ?? false)) {
                 continue;
             }
-
-            // Check if the template allows the usage of the module
-            if (true !== rex_template::hasModule($this->template_attributes, $ctype, $m['id'])) {
-                continue;
-            }
-            $moduleList .= '<li class="column">';
-            $moduleList .= '<a href="' . $context->getUrl(['module_id' => $m['id'], 'ctype' => $ctype]) . '" data-href="' . $context->getUrl(['module_id' => $m['id'], 'ctype' => $ctype]) . '" class="module" data-name="' . $m['id'] . '.jpg">';
-            $moduleList .= '<div class="header">' . rex_i18n::translate($m['name'], false) . '</div>';
-            if (!$hideImages) {
-                if ($loadImagesFromTheme && rex_addon::exists('theme') && rex_addon::get('theme')->isAvailable()) {
-                    $suffix = '';
-                    if (rex_config::get('developer', 'dir_suffix')) {
-                        $suffix = ' [' . $m['id'] . ']';
-                    }
-                    $image = theme_path::base('/private/redaxo/modules/' . $m['name'] . $suffix . '/module_preview.jpg');
-                } else {
-                    $image = rex_url::assets('addons/module_preview_modules/' . $m['id'] . '.jpg');
-
-                    if (array_key_exists('key', $m) && isset($m['key'])) {
-                        $image = rex_url::assets('addons/module_preview_modules/' . $m['key'] . '.jpg');
-                    }
+            foreach ($templateCtypes as $cTypeId => $cTypeName) {
+                // Check if the template allows the usage of the module
+                if (true !== rex_template::hasModule($this->template_attributes, $cTypeId, $m['id'])) {
+                    continue;
                 }
-
-                $moduleList .= '<div class="image"><div>';
-                if (file_exists($image)) {
-                    if ($loadImagesFromTheme) {
-                        $data = file_get_contents($image);
-                        $image = 'data:image/jpg;base64,' . base64_encode($data);
-                    }
-
-                    $moduleList .= '<img src="' . $image . '" alt="' . rex_i18n::translate($m['name'], false) . '">';
-                } else {
-                    $moduleList .= '<div class="not-available"></div>';
-                }
-                $moduleList .= '</div></div>';
+                $moduleList .= $this->moduleListItem($context, $m, $ctype, $hideImages, $loadImagesFromTheme);
             }
-            $moduleList .= '</a>';
-            $moduleList .= '</li>';
-
-            $slug = rex_string::normalize(rex_i18n::translate($m['name'], false), '-');
-            $this->modules[] = [
-                'name' => rex_i18n::translate($m['name'], false),
-                'slug' => $slug,
-                'id' => $m['id'],
-                'key' => $m['key'],
-                'imagePath' => rex_addon::get('module_preview')->getAssetsPath($slug . '.jpg'),
-            ];
         }
         $moduleList .= '</ul>';
         $moduleList .= '</div>';
@@ -134,6 +95,7 @@ class module_preview extends rex_article_content_editor
         $search = '<div class="container"><div class="form-group">';
         $search .= '<label class="control-label" for="module-preview-search"><input class="form-control" name="module-preview-search" type="text" id="module-preview-search" value="" placeholder="' . $addon->i18n('module_preview_search_modules') . '" /></label>';
         $search .= '</div></div>';
+
         return $search;
     }
 
@@ -160,5 +122,100 @@ class module_preview extends rex_article_content_editor
             $sql->setQuery('select ' . rex::getTablePrefix() . 'article_slice.article_id, ' . rex::getTablePrefix() . 'article_slice.module_id, ' . rex::getTablePrefix() . 'module.name from ' . rex::getTablePrefix() . 'article_slice left join ' . rex::getTablePrefix() . 'module on ' . rex::getTablePrefix() . 'article_slice.module_id=' . rex::getTablePrefix() . 'module.id where ' . rex::getTablePrefix() . 'article_slice.id=? and ' . rex::getTablePrefix() . 'article_slice.clang_id=?', [$sliceId, $clangId]);
             return $sql->getArray()[0];
         }
+    }
+
+    /**
+     * Create a list item HTML snippet for module selection
+     *
+     * @param rex_context $context             Current context
+     * @param array       $moduleData          Module data
+     * @param int         $ctype               Current content type
+     * @param bool        $hideImages          Shall images be hidden
+     * @param bool        $loadImagesFromTheme Are images loaded from theme
+     *
+     * @return string
+     */
+    private function moduleListItem(rex_context $context, array $moduleData, int $ctype, bool $hideImages, bool $loadImagesFromTheme): string
+    {
+        $moduleUrl = $context->getUrl(['module_id' => $moduleData['id'], 'ctype' => $ctype]);
+        $moduleName = rex_i18n::translate($moduleData['name'], false);
+        $imagePreview = (true !== $hideImages) ? $this->previewImageContainer($loadImagesFromTheme, $moduleData) : '';
+
+        $slug = rex_string::normalize(rex_i18n::translate($moduleData['name'], false), '-');
+        $this->modules[] = [
+            'name'      => rex_i18n::translate($moduleData['name'], false),
+            'slug'      => $slug,
+            'id'        => $moduleData['id'],
+            'key'       => $moduleData['key'],
+            'imagePath' => rex_addon::get('module_preview')->getAssetsPath($slug . '.jpg'),
+        ];
+
+        return <<<HTML
+            <li class="column">
+                <a href="{$moduleUrl}" data-href="{$moduleUrl}" class="module" data-name="{$moduleData['id']}.jpg">
+                    <div class="header">{$moduleName}</div>
+                    {$imagePreview}
+                </a>
+            </li>
+            HTML;
+    }
+
+    /**
+     * Create and return the markup for a DIV element containing the preview image as base64 encoded data string.
+     *
+     * @param bool  $loadImagesFromTheme
+     * @param array $moduleData
+     *
+     * @return string
+     */
+    private function previewImageContainer(bool $loadImagesFromTheme, array $moduleData): string
+    {
+        if ($loadImagesFromTheme && rex_addon::exists('theme') && rex_addon::get('theme')->isAvailable()) {
+            $suffix = '';
+            if (rex_config::get('developer', 'dir_suffix')) {
+                $suffix = ' [' . $moduleData['id'] . ']';
+            }
+            $image = theme_path::base('/private/redaxo/modules/' . $moduleData['name'] . $suffix . '/module_preview.jpg');
+        } else {
+            $image = rex_url::assets('addons/module_preview_modules/' . $moduleData['id'] . '.jpg');
+
+            if (array_key_exists('key', $moduleData) && isset($moduleData['key'])) {
+                $image = rex_url::assets('addons/module_preview_modules/' . $moduleData['key'] . '.jpg');
+            }
+        }
+        $preview = $this->imageFileToTag($image, $loadImagesFromTheme, rex_i18n::translate($moduleData['name'], false));
+
+        return <<<HTML
+            <div class="image">
+                <div>
+                    {$preview}
+                </div>
+            </div>
+            HTML;
+    }
+
+    /**
+     * Convert $imageFile to an IMG tag. If $loadImagesFromTheme is true, the src is set to the base64 encoded image
+     * data string.
+     * Returns a _not-available_ placeholder DIV tag if $imageFile does not exist.
+     *
+     * @param string $imageFile           Absolute image file to convert.
+     * @param bool   $loadImagesFromTheme Are images loaded from theme?
+     * @param string $moduleLabel         Localized label of the module the image is the preview for
+     *
+     * @return string
+     */
+    private function imageFileToTag(string $imageFile, bool $loadImagesFromTheme, string $moduleLabel): string
+    {
+        if (!file_exists($imageFile)) {
+            return '<div class="not-available"></div>';
+        }
+        $image = $imageFile;
+        if ($loadImagesFromTheme) {
+            $data = file_get_contents($imageFile);
+            $image = 'data:image/jpg;base64,' . base64_encode($data);
+        }
+
+        return "<img src=\"{$image}\" alt=\"{$moduleLabel}\">";
     }
 }

--- a/lib/module_preview.php
+++ b/lib/module_preview.php
@@ -74,50 +74,53 @@ class module_preview extends rex_article_content_editor
             if (true !== (rex::getUser()->getComplexPerm('modules')->hasPerm($m['id']) ?? false)) {
                 continue;
             }
-            if (rex_template::hasModule($this->template_attributes, $ctype, $m['id'])) {
-                $moduleList .= '<li class="column">';
-                $moduleList .= '<a href="' . $context->getUrl(['module_id' => $m['id'], 'ctype' => $ctype]) . '" data-href="' . $context->getUrl(['module_id' => $m['id'], 'ctype' => $ctype]) . '" class="module" data-name="' . $m['id'] . '.jpg">';
-                $moduleList .= '<div class="header">' . rex_i18n::translate($m['name'], false) . '</div>';
-                if (!$hideImages) {
-                    if ($loadImagesFromTheme && rex_addon::exists('theme') && rex_addon::get('theme')->isAvailable()) {
-                        $suffix = '';
-                        if (rex_config::get('developer', 'dir_suffix')) {
-                            $suffix = ' [' . $m['id'] . ']';
-                        }
-                        $image = theme_path::base('/private/redaxo/modules/' . $m['name'] . $suffix . '/module_preview.jpg');
-                    } else {
-                        $image = rex_url::assets('addons/module_preview_modules/' . $m['id'] . '.jpg');
 
-                        if (array_key_exists('key', $m) && isset($m['key'])) {
-                            $image = rex_url::assets('addons/module_preview_modules/' . $m['key'] . '.jpg');
-                        }
-                    }
-
-                    $moduleList .= '<div class="image"><div>';
-                    if (file_exists($image)) {
-                        if ($loadImagesFromTheme) {
-                            $data = file_get_contents($image);
-                            $image = 'data:image/jpg;base64,' . base64_encode($data);
-                        }
-
-                        $moduleList .= '<img src="' . $image . '" alt="' . rex_i18n::translate($m['name'], false) . '">';
-                    } else {
-                        $moduleList .= '<div class="not-available"></div>';
-                    }
-                    $moduleList .= '</div></div>';
-                }
-                $moduleList .= '</a>';
-                $moduleList .= '</li>';
-
-                $slug = rex_string::normalize(rex_i18n::translate($m['name'], false), '-');
-                $this->modules[] = [
-                    'name' => rex_i18n::translate($m['name'], false),
-                    'slug' => $slug,
-                    'id' => $m['id'],
-                    'key' => $m['key'],
-                    'imagePath' => rex_addon::get('module_preview')->getAssetsPath($slug . '.jpg'),
-                ];
+            // Check if the template allows the usage of the module
+            if (true !== rex_template::hasModule($this->template_attributes, $ctype, $m['id'])) {
+                continue;
             }
+            $moduleList .= '<li class="column">';
+            $moduleList .= '<a href="' . $context->getUrl(['module_id' => $m['id'], 'ctype' => $ctype]) . '" data-href="' . $context->getUrl(['module_id' => $m['id'], 'ctype' => $ctype]) . '" class="module" data-name="' . $m['id'] . '.jpg">';
+            $moduleList .= '<div class="header">' . rex_i18n::translate($m['name'], false) . '</div>';
+            if (!$hideImages) {
+                if ($loadImagesFromTheme && rex_addon::exists('theme') && rex_addon::get('theme')->isAvailable()) {
+                    $suffix = '';
+                    if (rex_config::get('developer', 'dir_suffix')) {
+                        $suffix = ' [' . $m['id'] . ']';
+                    }
+                    $image = theme_path::base('/private/redaxo/modules/' . $m['name'] . $suffix . '/module_preview.jpg');
+                } else {
+                    $image = rex_url::assets('addons/module_preview_modules/' . $m['id'] . '.jpg');
+
+                    if (array_key_exists('key', $m) && isset($m['key'])) {
+                        $image = rex_url::assets('addons/module_preview_modules/' . $m['key'] . '.jpg');
+                    }
+                }
+
+                $moduleList .= '<div class="image"><div>';
+                if (file_exists($image)) {
+                    if ($loadImagesFromTheme) {
+                        $data = file_get_contents($image);
+                        $image = 'data:image/jpg;base64,' . base64_encode($data);
+                    }
+
+                    $moduleList .= '<img src="' . $image . '" alt="' . rex_i18n::translate($m['name'], false) . '">';
+                } else {
+                    $moduleList .= '<div class="not-available"></div>';
+                }
+                $moduleList .= '</div></div>';
+            }
+            $moduleList .= '</a>';
+            $moduleList .= '</li>';
+
+            $slug = rex_string::normalize(rex_i18n::translate($m['name'], false), '-');
+            $this->modules[] = [
+                'name' => rex_i18n::translate($m['name'], false),
+                'slug' => $slug,
+                'id' => $m['id'],
+                'key' => $m['key'],
+                'imagePath' => rex_addon::get('module_preview')->getAssetsPath($slug . '.jpg'),
+            ];
         }
         $moduleList .= '</ul>';
         $moduleList .= '</div>';

--- a/lib/module_preview.php
+++ b/lib/module_preview.php
@@ -6,8 +6,8 @@ class module_preview extends rex_article_content_editor
 
     public function getModules(): string
     {
-        $hideImages = \rex_config::get('module_preview', 'hide_images');
-        $loadImagesFromTheme = \rex_config::get('module_preview', 'load_images_from_theme');
+        $hideImages = \rex_config::get('module_preview', 'hide_images', false);
+        $loadImagesFromTheme = \rex_config::get('module_preview', 'load_images_from_theme', false);
         $articleId = rex_request('article_id', 'int');
         $categoryId = rex_request('category_id', 'int');
         $clang = rex_request('clang', 'int');

--- a/lib/module_preview.php
+++ b/lib/module_preview.php
@@ -70,51 +70,53 @@ class module_preview extends rex_article_content_editor
         $this->modules = [];
 
         foreach ($modules as $m) {
-            if (rex::getUser()->getComplexPerm('modules')->hasPerm($m['id'])) {
-                if (rex_template::hasModule($this->template_attributes, $ctype, $m['id'])) {
-                    $moduleList .= '<li class="column">';
-                    $moduleList .= '<a href="' . $context->getUrl(['module_id' => $m['id'], 'ctype' => $ctype]) . '" data-href="' . $context->getUrl(['module_id' => $m['id'], 'ctype' => $ctype]) . '" class="module" data-name="' . $m['id'] . '.jpg">';
-                    $moduleList .= '<div class="header">' . rex_i18n::translate($m['name'], false) . '</div>';
-                    if (!$hideImages) {
-                        if ($loadImagesFromTheme && rex_addon::exists('theme') && rex_addon::get('theme')->isAvailable()) {
-                            $suffix = '';
-                            if (rex_config::get('developer', 'dir_suffix')) {
-                                $suffix = ' [' . $m['id'] . ']';
-                            }
-                            $image = theme_path::base('/private/redaxo/modules/' . $m['name'] . $suffix . '/module_preview.jpg');
-                        } else {
-                            $image = rex_url::assets('addons/module_preview_modules/' . $m['id'] . '.jpg');
-
-                            if (array_key_exists('key', $m) && isset($m['key'])) {
-                                $image = rex_url::assets('addons/module_preview_modules/' . $m['key'] . '.jpg');
-                            }
+            // Check if the user has permission to use the module
+            if (true !== (rex::getUser()->getComplexPerm('modules')->hasPerm($m['id']) ?? false)) {
+                continue;
+            }
+            if (rex_template::hasModule($this->template_attributes, $ctype, $m['id'])) {
+                $moduleList .= '<li class="column">';
+                $moduleList .= '<a href="' . $context->getUrl(['module_id' => $m['id'], 'ctype' => $ctype]) . '" data-href="' . $context->getUrl(['module_id' => $m['id'], 'ctype' => $ctype]) . '" class="module" data-name="' . $m['id'] . '.jpg">';
+                $moduleList .= '<div class="header">' . rex_i18n::translate($m['name'], false) . '</div>';
+                if (!$hideImages) {
+                    if ($loadImagesFromTheme && rex_addon::exists('theme') && rex_addon::get('theme')->isAvailable()) {
+                        $suffix = '';
+                        if (rex_config::get('developer', 'dir_suffix')) {
+                            $suffix = ' [' . $m['id'] . ']';
                         }
+                        $image = theme_path::base('/private/redaxo/modules/' . $m['name'] . $suffix . '/module_preview.jpg');
+                    } else {
+                        $image = rex_url::assets('addons/module_preview_modules/' . $m['id'] . '.jpg');
 
-                        $moduleList .= '<div class="image"><div>';
-                        if (file_exists($image)) {
-                            if ($loadImagesFromTheme) {
-                                $data = file_get_contents($image);
-                                $image = 'data:image/jpg;base64,' . base64_encode($data);
-                            }
-
-                            $moduleList .= '<img src="' . $image . '" alt="' . rex_i18n::translate($m['name'], false) . '">';
-                        } else {
-                            $moduleList .= '<div class="not-available"></div>';
+                        if (array_key_exists('key', $m) && isset($m['key'])) {
+                            $image = rex_url::assets('addons/module_preview_modules/' . $m['key'] . '.jpg');
                         }
-                        $moduleList .= '</div></div>';
                     }
-                    $moduleList .= '</a>';
-                    $moduleList .= '</li>';
 
-                    $slug = rex_string::normalize(rex_i18n::translate($m['name'], false), '-');
-                    $this->modules[] = [
-                        'name' => rex_i18n::translate($m['name'], false),
-                        'slug' => $slug,
-                        'id' => $m['id'],
-                        'key' => $m['key'],
-                        'imagePath' => rex_addon::get('module_preview')->getAssetsPath($slug . '.jpg'),
-                    ];
+                    $moduleList .= '<div class="image"><div>';
+                    if (file_exists($image)) {
+                        if ($loadImagesFromTheme) {
+                            $data = file_get_contents($image);
+                            $image = 'data:image/jpg;base64,' . base64_encode($data);
+                        }
+
+                        $moduleList .= '<img src="' . $image . '" alt="' . rex_i18n::translate($m['name'], false) . '">';
+                    } else {
+                        $moduleList .= '<div class="not-available"></div>';
+                    }
+                    $moduleList .= '</div></div>';
                 }
+                $moduleList .= '</a>';
+                $moduleList .= '</li>';
+
+                $slug = rex_string::normalize(rex_i18n::translate($m['name'], false), '-');
+                $this->modules[] = [
+                    'name' => rex_i18n::translate($m['name'], false),
+                    'slug' => $slug,
+                    'id' => $m['id'],
+                    'key' => $m['key'],
+                    'imagePath' => rex_addon::get('module_preview')->getAssetsPath($slug . '.jpg'),
+                ];
             }
         }
         $moduleList .= '</ul>';


### PR DESCRIPTION
Eigentlich fügt dieser PR nur ein zusätzliches `foreach` für die cTypes hinzu, so wie es in der Methode [rex_article_content_editor::preArticle()](https://github.com/redaxo/redaxo/blob/2c350d13c476862748cff6ee927f098910654050/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php#L341), an welcher sich die Logik wohl orientiert, auch passiert.

Da ich mich nicht ganz wohl gefühlt habe, dem schon recht stark eingerückten Quellcode noch eine zusätzliche Ebene der Einrückung hinzuzufügen, habe ich erste zwei Ebenen Einrücken entfernt und eine kleine Refakturierung vorgenommen um alles trotz zusätzlicher Schleife noch übersichtlich zu halten.

This fixes #10 