### PR TITLE
PNG Bilder als Preview erlauben

### DIFF
--- a/fragments/module_preview/image-upload.php
+++ b/fragments/module_preview/image-upload.php
@@ -2,20 +2,15 @@
 /** @var rex_fragment $this */
 
 $module = $this->getVar('module');
-$image = rex_url::assets('addons/module_preview_modules/' . $module['id'] . '.jpg');
-$key = '';
 
-if (array_key_exists('key', $module) && isset($module['key'])) {
-    $image = rex_url::assets('addons/module_preview_modules/' . $module['key'] . '.jpg');
-    $key = ' <span>[' . $module['key'] . ']</span>';
-}
+['image' => $image, 'moduleKey' => $key] = module_preview::getModulePreviewImage($module);
 ?>
 
 <div class="module-col">
-    <div class="name"><strong><?= $module['name'] ?></strong> <span>[<?= $module['id'] ?>]</span><?= $key ?></div>
+    <div class="name"><strong><?= $module['name'] ?></strong> <span>[<?= $module['id'] ?>]</span><?= $key ?? '' ?></div>
     <div class="module rex-form-group form-group">
         <div class="image">
-            <?php if (file_exists($image)) : ?>
+            <?php if (null !== $image) : ?>
                 <button class="delete-image" data-image="<?= $image ?>" value="delete_image">
                     <i class="fa fa-trash" aria-hidden="true"></i>
                 </button>
@@ -26,7 +21,7 @@ if (array_key_exists('key', $module) && isset($module['key'])) {
         </div>
         <div class="file" style="margin-top: 5px;">
             <label class="form-label file-label">
-                <input type="file" id="module-<?= $module['id'] ?>" class="module-image-input" name="module_<?= $module['id'] ?>" accept="image/jpeg">
+                <input type="file" id="module-<?= $module['id'] ?>" class="module-image-input" name="module_<?= $module['id'] ?>" accept="image/jpeg,image/png">
                 <span class="btn btn-default"><?= rex_i18n::msg('module_preview_select_image') ?></span>
             </label>
         </div>

--- a/lib/module_preview.php
+++ b/lib/module_preview.php
@@ -56,8 +56,9 @@ class module_preview extends rex_article_content_editor
             $context->setParam('source_slice_id', $clipBoardContents['slice_id']);
 
             if ($sliceDetails['article_id']) {
+                $moduleLink = $context->getUrl(['module_id' => $sliceDetails['module_id'], 'ctype' => $ctype]);
                 $moduleList .= '<li class="column large">';
-                $moduleList .= '<a href="' . $context->getUrl(['module_id' => $sliceDetails['module_id'], 'ctype' => $ctype]) . '" data-href="' . $context->getUrl(['module_id' => $sliceDetails['module_id'], 'ctype' => $ctype]) . '" class="module" data-name="' . $sliceDetails['module_id'] . '.jpg">';
+                $moduleList .= "<a href=\"{$moduleLink}\" data-href=\"{$moduleLink}\" class=\"module\" data-name=\"{$sliceDetails['module_id']}.jpg\">";
                 $moduleList .= '<div class="header">';
                 if ('copy' === $clipBoardContents['action']) {
                     $moduleList .= '<i class="fa fa-clipboard" aria-hidden="true" style="margin-right: 5px;"></i>';
@@ -209,11 +210,7 @@ class module_preview extends rex_article_content_editor
             }
             $image = theme_path::base('/private/redaxo/modules/' . $moduleData['name'] . $suffix . '/module_preview.jpg');
         } else {
-            $image = rex_url::assets('addons/module_preview_modules/' . $moduleData['id'] . '.jpg');
-
-            if (array_key_exists('key', $moduleData) && isset($moduleData['key'])) {
-                $image = rex_url::assets('addons/module_preview_modules/' . $moduleData['key'] . '.jpg');
-            }
+            ['image' => $image] = static::getModulePreviewImage($moduleData);
         }
         $preview = $this->imageFileToTag($image, $loadImagesFromTheme, rex_i18n::translate($moduleData['name'], false));
 
@@ -235,9 +232,9 @@ class module_preview extends rex_article_content_editor
      * @param bool   $loadImagesFromTheme Are images loaded from theme?
      * @param string $moduleLabel         Localized label of the module the image is the preview for
      */
-    private function imageFileToTag(string $imageFile, bool $loadImagesFromTheme, string $moduleLabel): string
+    private function imageFileToTag(?string $imageFile, bool $loadImagesFromTheme, string $moduleLabel): string
     {
-        if (!file_exists($imageFile)) {
+        if (null === $imageFile || !file_exists($imageFile)) {
             return '<div class="not-available"></div>';
         }
         $image = $imageFile;

--- a/lib/module_preview.php
+++ b/lib/module_preview.php
@@ -125,6 +125,35 @@ class module_preview extends rex_article_content_editor
         return @json_decode(rex_request::cookie('rex_bloecks_cutncopy', 'string', ''), true);
     }
 
+    /**
+     * Get the preview image for a module and, if set, the key of the module as a `span` HTML snippet
+     *
+     * @param array $module
+     *
+     * @return array{image: ?string, moduleKey: ?string}
+     */
+    public static function getModulePreviewImage(array $module): array
+    {
+        // If the module has a key set, use the key to identify the image. Else use the ID of the module
+        if (empty($module['key'] ?? null)) {
+            $key = null;
+            $imageName = $module['id'];
+        } else {
+            $key = ' <span>[' . $module['key'] . ']</span>';
+            $imageName = $module['key'];
+        }
+
+        // Search the preview directory for valid images
+        $globPattern = rex_url::assets('addons/module_preview_modules/') . "{$imageName}.*";
+        $foundImages = glob($globPattern);
+        $validImages = false !== $foundImages ? preg_grep('/^.*(jpe?g|png)/', $foundImages) : [];
+
+        return [
+            'image'     => (empty($validImages)) ? null : reset($validImages),
+            'moduleKey' => $key,
+        ];
+    }
+
     private function getSliceDetails($sliceId, $clangId)
     {
         if ($sliceId && $clangId) {

--- a/pages/modules.php
+++ b/pages/modules.php
@@ -51,7 +51,7 @@ if (rex_version::compare(rex::getVersion(), '5.12.0', '<')) {
             }
 
             $uploadedImage = new UploadedFile($tmpImage['tmp_name'], $tmpImage['name'], $tmpImage['type'], $tmpImage['error']);
-            $uploadedImage->move($targetDir, $fileName . '.jpg');
+            $uploadedImage->move($targetDir, "{$fileName}.{$uploadedImage->getClientOriginalExtension()}");
             ++$imageCount;
         }
 


### PR DESCRIPTION
Ich habe die Stellen umgeschrieben, an denen die Dateiendung .jpg hard-gecoded war um auch den Upload von .png Dateien zu ermöglichen, da ich PNG als Vorschau wegen der Qualität angenehmer finde.

Folgende Stellen habe ich nicht angepasst:
- Bei Bilder mit dem Modus "aus dem Theme" wird das Bild als Base64 und Typ jpeg inline angezeigt. Da ich den Mechanismus nicht testen konnte, habe ich ihn fix auf jpg gelassen.
- Im erzeugten HTML Gitter mit den Bildern wird an einigen Stellen ein Daten-Attribut gesetzt, welches jpg als Endung verwendet. Mir war nicht sicher, wie relevant das Datenattribut für den flüssigen Ablauf sind und ob eine Anpassung nötig ist.

Falls es noch Fragen gibt, werde ich leider erst in zwei Wochen wieder antworten können.